### PR TITLE
feat: Automerge digest PRs

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,4 +1,7 @@
 {
+  "digest": {
+    "automerge": true
+  },
   "extends": [
     "config:base",
     "docker:enableMajor",


### PR DESCRIPTION
Digest updates shouldn't change anything important (likely dependency updates upstream), so we should just pull them in. Though renovate will still only automerge if the tests all pass